### PR TITLE
chore: Specify Node.js version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Root
 
 ### 1️⃣ Prerequisites
 Ensure you have **Node.js** and **npm** installed:
+
+**Note: This project requires Node.js 18 or later.**
 ```
 node -v  # Check Node.js version
 npm -v   # Check npm version

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "build": "webpack --config webpack.prod.js --mode production",
     "test": "jest"
   },
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "jest": {
     "testEnvironment": "jsdom"
   },


### PR DESCRIPTION
- Added "engines" field in package.json to specify Node.js >=18.
- Updated README.md to clearly state that Node.js 18 or later is required.